### PR TITLE
compiler: Add a SymGenerator() for FrameScopeLayout.

### DIFF
--- a/monte/compiler.py
+++ b/monte/compiler.py
@@ -162,6 +162,7 @@ class FrameScopeLayout(object):
                                        FRAME)
         else:
             self.selfBinding = None
+        self.gensym = SymGenerator().gensym
         self.fields = [self._createBinding(f) for f in fields]
         self.fqnPrefix = fqnPrefix
 
@@ -169,7 +170,7 @@ class FrameScopeLayout(object):
         if f.name not in self.verbs:
             pyname = f.pyname
         else:
-            pyname =  self.gensym(mangleIdent(f.name))
+            pyname = self.gensym(mangleIdent(f.name))
         if f.kind == FRAME:
             return Binding(f.node, self.selfName + '.' + pyname.rpartition('.')[2],
                            '_monte.getGuard(%s, "%s")' % (self.selfName, f.name),


### PR DESCRIPTION
It seems that without this, SymGenerators simply aren't present for generating de Brujin names inside frame-level scopes.
