### PR TITLE
{uuid}.py is not a valid module name.

### DIFF
--- a/monte/runtime.py
+++ b/monte/runtime.py
@@ -858,7 +858,7 @@ jacklegScope = {
 }
 
 def eval(source, scope=jacklegScope, origin="__main"):
-    name = uuid.uuid4().hex + '.py'
+    name = uuid.uuid4().hex
     mod = module(name)
     mod.__name__ = name
     mod._m_outerScope = scope


### PR DESCRIPTION
This fixes the "7227f3e988824fab80ce56d1bd32c083.py:1: RuntimeWarning: Parent module '7227f3e988824fab80ce56d1bd32c083' not found while handling absolute import error" for me.

r?
