### PR TITLE
fix code-block errors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ To use the Monte implementation hosted in Python, it's best to set up a
 virtualenv: 
 
 .. code-block:: console
+
     $ virtualenv v
     $ source v/bin/activate
     $ pip install -r requirements.txt
@@ -35,6 +36,7 @@ virtualenv:
 To run Monte code (with your virtualenv activated): 
 
 .. code-block:: console
+
     $ bin/monte monte/src/examples/hello.mt
 
 The Repl


### PR DESCRIPTION
code-block can take additional arguments, so you need a blank line between the
directive and the code block.
