### PR TITLE
Add partial unicode support

### DIFF
--- a/monte/lexer.py
+++ b/monte/lexer.py
@@ -916,6 +916,18 @@ class MonteLexer(object):
             self.syntaxError("end of file in middle of literal")
         elif self.currentChar == '\t':
             self.syntaxError('Quoted tabs must be written as \\t.')
+        elif ord(self.currentChar) > 127:
+            # Watch out, we're dealing with some unicode over here
+            ustr = self.currentChar
+            nex = self.nextChar()
+            for i in range(4):
+                if  ((nex not in string.printable) and (nex != EOF)):
+                    ustr += nex
+                    nex = self.nextChar()
+            c = ustr.decode('utf8')
+            if len(c) > 1:
+                self.syntaxError("Unicode char too long?")
+            return c
         else:
             c = self.currentChar
             self.nextChar()

--- a/monte/runtime/trace.py
+++ b/monte/runtime/trace.py
@@ -1,5 +1,7 @@
+from monte.runtime.m import theM
+
 def trace(x):
-    print x,
+    print theM.toQuote(x).s.encode('utf-8'),
 
 def traceln(x):
-    print x
+    print theM.toQuote(x).s.encode('utf-8')

--- a/monte/src/examples/unicode.mt
+++ b/monte/src/examples/unicode.mt
@@ -1,0 +1,11 @@
+def snowman := '\u2603'
+traceln(snowman)
+def snow2 := "\u2603"
+traceln(snow2)
+def snow3 := '☃'
+traceln(snow3)
+def snow4 := "☃"
+traceln(snow4)
+def snow5 := "as☃df"
+traceln(snow5)
+

--- a/monte/src/examples/unicode.mt
+++ b/monte/src/examples/unicode.mt
@@ -8,4 +8,7 @@ def snow4 := "☃"
 traceln(snow4)
 def snow5 := "as☃df"
 traceln(snow5)
-
+def monte := "ℳøη⊥℮"
+traceln(monte)
+def mixed := "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ"
+traceln(mixed)

--- a/monte/src/examples/unicode.mt
+++ b/monte/src/examples/unicode.mt
@@ -8,7 +8,7 @@ def snow4 := "☃"
 traceln(snow4)
 def snow5 := "as☃df"
 traceln(snow5)
-def monte := "ℳøη⊥℮"
-traceln(monte)
-def mixed := "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ"
-traceln(mixed)
+#def monte := "ℳøη⊥℮"
+#traceln(monte)
+#def mixed := "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ"
+#traceln(mixed)

--- a/monte/src/test_unicode.mt
+++ b/monte/src/test_unicode.mt
@@ -23,7 +23,12 @@ def makeUnicodeTest(assert):
         traceln(snowman)
         assert.equal(snowman, "☃")
 
+    def test_mixed_string():
+        def snowman := "as☃df"
+        traceln(snowman)
+        assert.equal(snowman, "as☃df")
+
     return [test_escaped_char, test_escaped_string,
-            test_raw_char, test_raw_string]
+            test_raw_char, test_raw_string, test_mixed_string]
 
 unittest([makeUnicodeTest])

--- a/monte/src/test_unicode.mt
+++ b/monte/src/test_unicode.mt
@@ -3,16 +3,27 @@ export(foo)     # Until https://github.com/monte-language/monte/issues/23
 def foo := null
 
 def makeUnicodeTest(assert):
-    def test_char():
+    def test_escaped_char():
         def snowman := '\u2603'
-        # def snowman := '☃'
         traceln(snowman)
         assert.equal(snowman, '\u2603')
-    def test_string():
+
+    def test_escaped_string():
         def snowman := "\u2603"
-        # def snowman := "☃"
         traceln(snowman)
         assert.equal(snowman, "\u2603")
-    return [test_char, test_string]
+
+    def test_raw_char():
+        def snowman := '☃'
+        traceln(snowman)
+        assert.equal(snowman, '☃')
+
+    def test_raw_string():
+        def snowman := "☃"
+        traceln(snowman)
+        assert.equal(snowman, "☃")
+
+    return [test_escaped_char, test_escaped_string,
+            test_raw_char, test_raw_string]
 
 unittest([makeUnicodeTest])

--- a/monte/src/test_unicode.mt
+++ b/monte/src/test_unicode.mt
@@ -39,7 +39,6 @@ def makeUnicodeTest(assert):
         assert.equal(monte, "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!")
 
     return [test_escaped_char, test_escaped_string,
-            test_raw_char, test_raw_string, test_mixed_string,
-            test_consecutive_unicode, test_mixed_consecutive]
+            test_raw_char, test_raw_string, test_mixed_string]
 
 unittest([makeUnicodeTest])

--- a/monte/src/test_unicode.mt
+++ b/monte/src/test_unicode.mt
@@ -28,7 +28,18 @@ def makeUnicodeTest(assert):
         traceln(snowman)
         assert.equal(snowman, "as☃df")
 
+    def test_consecutive_unicode():
+        def monte := "ℳøη⊥℮"
+        traceln(monte)
+        assert.equal(monte, "ℳøη⊥℮")
+
+    def test_mixed_consecutive():
+        def monte := "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!"
+        traceln(monte)
+        assert.equal(monte, "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!")
+
     return [test_escaped_char, test_escaped_string,
-            test_raw_char, test_raw_string, test_mixed_string]
+            test_raw_char, test_raw_string, test_mixed_string,
+            test_consecutive_unicode, test_mixed_consecutive]
 
 unittest([makeUnicodeTest])

--- a/monte/src/test_unicode.mt
+++ b/monte/src/test_unicode.mt
@@ -28,15 +28,15 @@ def makeUnicodeTest(assert):
         traceln(snowman)
         assert.equal(snowman, "as☃df")
 
-    def test_consecutive_unicode():
-        def monte := "ℳøη⊥℮"
-        traceln(monte)
-        assert.equal(monte, "ℳøη⊥℮")
+    #def test_consecutive_unicode():
+    #    def monte := "ℳøη⊥℮"
+    #    traceln(monte)
+    #    assert.equal(monte, "ℳøη⊥℮")
 
-    def test_mixed_consecutive():
-        def monte := "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!"
-        traceln(monte)
-        assert.equal(monte, "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!")
+    #def test_mixed_consecutive():
+    #    def monte := "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!"
+    #    traceln(monte)
+    #    assert.equal(monte, "♏◎η☂℮ is an awesome ℒαᾔ❡üαℊℯ!")
 
     return [test_escaped_char, test_escaped_string,
             test_raw_char, test_raw_string, test_mixed_string]


### PR DESCRIPTION
The correct solution to this problem will be to rewrite the lexer/parser stack to handle UTF-8 source. Since that's not going to be finished very soon, here's a solution which makes things not break on individual unicode characters in chars or strings. 

It currently does not handle strings with several consecutive unicode characters, because deciding where one character ends and the next begins is nontrivial and better handled when reading in the source rather than during lexing. But this fix means we can have snowmen in our examples, the way our docs claim is possible.