### PR TITLE
8digit unicode

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -170,9 +170,11 @@ Char
 Monte's character type is distinct from the string type. Characters are always
 surrounded by apostrophes (``'``) and are always unicode.
 
-.. warning:: In Python, you may be accustomed to 'single' and "double" quotes
-    functioning interchangeably. In Monte, double quotes can contain any number
-    of letters, but single quotes can only hold a single character. 
+.. warning:: 
+
+    In Python, you may be accustomed to 'single' and "double" quotes
+    functioning interchangeably. In Monte, double quotes can contain any
+    number of letters, but single quotes can only hold a single character. 
 
 .. code-block:: monte
 
@@ -184,8 +186,8 @@ String
 ~~~~~~
 
 Strings are objects with built-in methods and capabilities, rather than
-character arrays. Monte's strings are always Unicode, like Python 3 (but
-unlike Python 2). Strings are always surrounded by double-quotes (`"`).
+character arrays. Monte's strings are always unicode, like Python 3 (but
+unlike Python 2). Strings are always surrounded by double-quotes (``"``).
 
 .. code-block:: monte
 
@@ -203,6 +205,54 @@ in Python::
 
     def l := ['I', "love", "Monte", 42, 0.5]
     def x := l[3] # x == 42
+
+Special Characters
+------------------
+
+In lists and strings, special characters and unicode values can be escaped: 
+
++-----------------+---------------------------------+
+| Escape Sequence | Meaning                         |
++=================+=================================+
+| ``\\``          | Backslash (``\``)               |
++-----------------+---------------------------------+
+| ``\'``          | Single quote (``'``)            |
++-----------------+---------------------------------+
+| ``\"``          | Double quote (``"``)            |
++-----------------+---------------------------------+
+| ``\b``          | ASCII Backspace (BS)            |
++-----------------+---------------------------------+
+| ``\f``          | ASCII Formfeed (FF)             |
++-----------------+---------------------------------+
+| ``\n``          | ASCII Linefeed (LF)             |
++-----------------+---------------------------------+
+| ``\r``          | ASCII Carriage Return (CR)      |
++-----------------+---------------------------------+
+| ``\t``          | ASCII Horizontal Tab (TAB)      |
++-----------------+---------------------------------+
+| ``\uxxxx``      | Character with 16-bit hex value |
+|                 | *xxxx* (Unicode only)           |
++-----------------+---------------------------------+
+| ``\Uxxxxxxxx``  | Character with 32-bit hex value |
+|                 | *xxxxxxxx* (Unicode only)       |
++-----------------+---------------------------------+
+| ``\xhh``        | Character with hex value *hh*   |
++-----------------+---------------------------------+
+
+(table mostly from `the Python docs <https://docs.python.org/2/_sources/reference/lexical_analysis.txt>`_)
+
+.. note:: 
+
+    Monte intentionally avoids supporting ASCII vertical tabs (``\v``) and
+    octal values (``\o00``) because it is a language of the future and in the
+    future, nobody uses those. 
+
+.. note::
+
+    As with Python, a backslash (``\``) as the final character of a line
+    escapes the newline and causes that line and its successor to be
+    interpereted as one.
+
 
 Data Structures
 ---------------

--- a/monte/lexer.py
+++ b/monte/lexer.py
@@ -924,7 +924,7 @@ class MonteLexer(object):
                 '"': '"',
                 '\'': "'",
                 '\\': '\\',
-                '\n': None
+                '\n': None      # escaped newline for continuation
                 }.get(nex, -1)
             if c == -1:
                 self.syntaxError("Unrecognized escaped character " + repr(nex))

--- a/monte/lexer.py
+++ b/monte/lexer.py
@@ -890,7 +890,7 @@ class MonteLexer(object):
                 try:
                     v = int(hexstr, 16)
                 except ValueError:
-                    self.syntaxError('\\U escape takes 8 hex digits')
+                    self.syntaxError('\\U escape must be eight hex digits')
                 else:
                     self.nextChar()
                     return unichr(v)

--- a/monte/src/monte_lexer.mt
+++ b/monte/src/monte_lexer.mt
@@ -166,6 +166,15 @@ def _makeMonteLexer(input, braceStack, var nestLevel):
     def charConstant(fail):
         if (currentChar == '\\'):
             def nex := advance()
+            if (nex == 'U'):
+                def hexstr := __makeString.fromChars([advance() for _ in 0..!8])
+                def v
+                try:
+                    bind v := __makeInt(hexstr, 16)
+                catch _:
+                    throw.eject(fail, "\\U escape must be eight hex digits")
+                advance()
+                return __makeCharacter(v)
             if (nex == 'u'):
                 def hexstr := __makeString.fromChars([advance() for _ in 0..!4])
                 def v

--- a/monte/test/test_lexer.py
+++ b/monte/test/test_lexer.py
@@ -21,21 +21,29 @@ class LexerTests(unittest.TestCase):
         self.assertEqual(lex("'\\U00008000'"),[Term(Tag(".char."), u'\U00008000', None, None)])
         self.assertEqual(lex("'\\u0061'"),    [Term(Tag(".char."), "a", None, None)])
         self.assertEqual(lex("'\\x61'"),      [Term(Tag(".char."), "a", None, None)])
+        self.assertEqual(lex("'\\\\'"),         [Term(Tag(".char."), "\\", None, None)])
+        self.assertEqual(lex("'\f'"),         [Term(Tag(".char."), "\f", None, None)])
+        self.assertEqual(lex("'\\''"),         [Term(Tag(".char."), "'", None, None)])
+
 
     def test_string(self):
         self.assertEqual(lex('"foo\\\nbar"'), [Term(Tag(".String."), 'foobar', None, None)])
         self.assertEqual(lex('"foo"'),        [Term(Tag(".String."), 'foo', None, None)])
         self.assertEqual(lex('"foo bar 9"'),  [Term(Tag(".String."), 'foo bar 9', None, None)])
         self.assertEqual(lex('"a\\U00008000"'),[Term(Tag(".String."), u'a\U00008000', None, None)])
+        self.assertEqual(lex('"\\ta\\U00008000"'),[Term(Tag(".String."), u"\ta\U00008000", None, None)])
         self.assertEqual(lex('"\\U00008000"'),[Term(Tag(".String."), u'\U00008000', None, None)])
         self.assertEqual(lex('"abc\\u0061"'), [Term(Tag(".String."), 'abca', None, None)])
         self.assertEqual(lex('"\\u0061 bc"'), [Term(Tag(".String."), 'a bc', None, None)])
         self.assertEqual(lex('"\\u0061"'),    [Term(Tag(".String."), 'a', None, None)])
         self.assertEqual(lex('"\\x61"'),      [Term(Tag(".String."), 'a', None, None)])
+        self.assertEqual(lex('"\\x61\\tb"'),   [Term(Tag(".String."), 'a\tb', None, None)])
         self.assertEqual(lex('"\\\n\\x61"'),  [Term(Tag(".String."), 'a', None, None)])
         self.assertEqual(lex('"w\\x61t"'),    [Term(Tag(".String."), 'wat', None, None)])
+        self.assertEqual(lex('"foo\\nbar"'),  [Term(Tag(".String."), 'foo\nbar', None, None)])
+        self.assertEqual(lex('"\\t\\n\\f\\r\\\\"'),[Term(Tag(".String."),'\t\n\f\r\\', None, None)])
 
-       self.assertEqual(lex('"foo\\nbar"'),  [Term(Tag(".String."), 'foo\nbar', None, None)])
+
 
     def test_integer(self):
         self.assertEqual(lex('0'),          [Term(Tag(".int."), 0, None, None)])

--- a/monte/test/test_lexer.py
+++ b/monte/test/test_lexer.py
@@ -26,7 +26,16 @@ class LexerTests(unittest.TestCase):
         self.assertEqual(lex('"foo\\\nbar"'), [Term(Tag(".String."), 'foobar', None, None)])
         self.assertEqual(lex('"foo"'),        [Term(Tag(".String."), 'foo', None, None)])
         self.assertEqual(lex('"foo bar 9"'),  [Term(Tag(".String."), 'foo bar 9', None, None)])
-        self.assertEqual(lex('"foo\\nbar"'),  [Term(Tag(".String."), 'foo\nbar', None, None)])
+        self.assertEqual(lex('"a\\U00008000"'),[Term(Tag(".String."), u'a\U00008000', None, None)])
+        self.assertEqual(lex('"\\U00008000"'),[Term(Tag(".String."), u'\U00008000', None, None)])
+        self.assertEqual(lex('"abc\\u0061"'), [Term(Tag(".String."), 'abca', None, None)])
+        self.assertEqual(lex('"\\u0061 bc"'), [Term(Tag(".String."), 'a bc', None, None)])
+        self.assertEqual(lex('"\\u0061"'),    [Term(Tag(".String."), 'a', None, None)])
+        self.assertEqual(lex('"\\x61"'),      [Term(Tag(".String."), 'a', None, None)])
+        self.assertEqual(lex('"\\\n\\x61"'),  [Term(Tag(".String."), 'a', None, None)])
+        self.assertEqual(lex('"w\\x61t"'),    [Term(Tag(".String."), 'wat', None, None)])
+
+       self.assertEqual(lex('"foo\\nbar"'),  [Term(Tag(".String."), 'foo\nbar', None, None)])
 
     def test_integer(self):
         self.assertEqual(lex('0'),          [Term(Tag(".int."), 0, None, None)])


### PR DESCRIPTION
* clean up some rst formatting
* add table of special characters to intro doc
* standardize lexer error wording
* add \U to the lexer.mt
* add some tests for mixed unicode, ascii, and escaped characters in strings