### PR TITLE
add_stylesheet('railroad-diagrams.css') for syntax diagrams

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,9 @@ sys.path.insert(0, os.path.abspath('.'))
 # ones.
 extensions = ['rr_ext']
 
+def setup(app):
+    app.add_stylesheet('railroad-diagrams.css')
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
After reading thru https://github.com/rtfd/readthedocs.org/issues/518
and experimenting, this seems to be the way to get the syntax diagram
style sheets right on readthedocs.org