### PR TITLE
fix: wrong links to issues (swapped)

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -256,8 +256,8 @@ We welcome feedback:
 
 Or come say hi on IRC, in `#monte` on `irc.freenode.net`!
 
-__ https://github.com/monte-language/monte/issues
 __ https://github.com/monte-language/typhon/issues
+__ https://github.com/monte-language/monte/issues
 
 
 Acknowledgements


### PR DESCRIPTION
The links in the https://monte.readthedocs.io/en/latest/intro.html#support-and-feedback section went to the wrong issues pages. This swaps them back.